### PR TITLE
Remove erroneous newline character (rt #98446)

### DIFF
--- a/Syslog.pm
+++ b/Syslog.pm
@@ -454,7 +454,7 @@ sub syslog {
     if ($options{perror} and $current_proto ne 'native') {
         my $whoami = $ident;
         $whoami .= "[$$]" if $options{pid};
-        print STDERR "$whoami: $message\n";
+        print STDERR "$whoami: $message";
     }
 
     # it's possible that we'll get an error from sending


### PR DESCRIPTION
Here's a Pull Request for the patch in https://rt.cpan.org/Ticket/Display.html?id=98446

Making this change didn't break any of the tests on my system (Ubuntu Linux 14.10, Perl 5.18) ... I would have liked to have added a test but I couldn't figure out where to put it or how to write it. Sorry!