### PR TITLE
Eliminate two arg open

### DIFF
--- a/Syslog.pm
+++ b/Syslog.pm
@@ -516,7 +516,7 @@ sub _syslog_send_console {
 	    }
 	}
     } else {
-        if (open(CONS, ">/dev/console")) {
+        if (open(CONS, '>', "/dev/console")) {
 	    my $ret = print CONS $buf . "\r";  # XXX: should this be \x0A ?
 	    POSIX::_exit($ret) if defined $pid;
 	    close CONS;
@@ -750,7 +750,7 @@ sub connect_pipe {
         return 0;
     }
 
-    if (not open(SYSLOG, ">$syslog_path")) {
+    if (not open(SYSLOG, ">", $syslog_path)) {
         push @$errs, "can't write to $syslog_path: $!";
         return 0;
     }

--- a/t/syslog.t
+++ b/t/syslog.t
@@ -241,8 +241,8 @@ SKIP: {
     # setlogsock() with "stream" and a local file
     SKIP: {
         my $logfile = "test.log";
-        open(LOG, ">$logfile") or skip "can't create file '$logfile': $!", 2;
-        close(LOG);
+        open(my $fh_log, ">", $logfile) or skip "can't create file '$logfile': $!", 2;
+        close($fh_log);
         $r = eval { setlogsock("stream", $logfile ) } || '';
         is( $@, '', "setlogsock() called, with 'stream' and '$logfile' (file exists)" );
         ok( $r, "setlogsock() should return true: '$r'" );
@@ -304,7 +304,7 @@ SKIP: {
 
     # create the log file
     my $log = "t/stream";
-    open my $fh, ">$log" or skip "can't write file '$log': $!", 3;
+    open my $fh, ">", $log or skip "can't write file '$log': $!", 3;
     close $fh;
 
     # configure Sys::Syslog to use it


### PR DESCRIPTION
Replaced a few 2-arg opens with 3-arg opens.

Maybe this can't be merged because of Perl 5.6 support?

For similar reasons I was going to replace all global bareword filehandles with lexical scalar filehandles but I thought that might also be a nod to Perl 5.6? But then there already is one lexical filehandle in in syslog.t line 307 so... not sure?