### PR TITLE
Perl Critic on eg/syslog.pl

### DIFF
--- a/eg/syslog.pl
+++ b/eg/syslog.pl
@@ -10,7 +10,7 @@ use Sys::Syslog;
 die "usage: $PROGRAM_NAME facility/priority message\n" unless @ARGV;
 
 my ($facility, $priority) = split '/', shift;
-my $message = join ' ', @ARGV;
+my $message = join q{ }, @ARGV;
 
 openlog($PROGRAM_NAME, "ndelay,pid", $facility) or die "fatal: can't open syslog: $OS_ERROR\n";
 syslog($priority, "%s", $message);

--- a/eg/syslog.pl
+++ b/eg/syslog.pl
@@ -1,5 +1,8 @@
 #!/usr/bin/perl
+
 use strict;
+use warnings;
+
 use Sys::Syslog;
 
 die "usage: $0 facility/priority message\n" unless @ARGV;

--- a/eg/syslog.pl
+++ b/eg/syslog.pl
@@ -9,7 +9,7 @@ use Sys::Syslog;
 
 die "usage: $PROGRAM_NAME facility/priority message\n" unless @ARGV;
 
-my ($facility, $priority) = split '/', shift;
+my ($facility, $priority) = split m{/}msx, shift;
 my $message = join q{ }, @ARGV;
 
 openlog($PROGRAM_NAME, "ndelay,pid", $facility) or die "fatal: can't open syslog: $OS_ERROR\n";

--- a/eg/syslog.pl
+++ b/eg/syslog.pl
@@ -3,13 +3,15 @@
 use strict;
 use warnings;
 
+use English '-no_match_vars';
+
 use Sys::Syslog;
 
-die "usage: $0 facility/priority message\n" unless @ARGV;
+die "usage: $PROGRAM_NAME facility/priority message\n" unless @ARGV;
 
 my ($facility, $priority) = split '/', shift;
 my $message = join ' ', @ARGV;
 
-openlog($0, "ndelay,pid", $facility) or die "fatal: can't open syslog: $!\n";
+openlog($PROGRAM_NAME, "ndelay,pid", $facility) or die "fatal: can't open syslog: $OS_ERROR\n";
 syslog($priority, "%s", $message);
 closelog();


### PR DESCRIPTION
If you're going to give an example, might as well make it exemplar :-)

If I was going all out I would have used Getopt::Long and Pod::Usage to make a real script out of it, but I decided to just address the basic Perl::Critic complaints about it.

Syslog.pm contains a lot of Perl::Critic violations too, but I'm too afraid to change anything lest the Perl 5.6 support be broken. I tried installing Perl 5.6 using perlbrew but compilation failed. Shame.