### PR TITLE
CVE-2016-1238: avoid loading optional modules from default .

### DIFF
--- a/Syslog.pm
+++ b/Syslog.pm
@@ -918,6 +918,8 @@ sub silent_eval (&) {
 sub can_load {
     my ($module, $verbose) = @_;
     local($SIG{__DIE__}, $SIG{__WARN__}, $@);
+    local @INC = @INC;
+    pop @INC if $INC[-1] eq '.';
     my $loaded = eval "use $module; 1";
     warn $@ if not $loaded and $verbose;
     return $loaded


### PR DESCRIPTION
Sys::Syslog treats two modules as optional, attemptting to load them
and not requiring them (Win32 only.)

If a user runs a program using Sys::Syslog in a world writable
directory (like %windir%\Temp) a local attacker can create
Win32\EventLog.pm in that directory to run code as the running user.

This patch temporarily removes the default . from @INC to prevent
that attack.