### PR TITLE
Remove links to search.cpan.org

### DIFF
--- a/README
+++ b/README
@@ -38,9 +38,6 @@ SUPPORT AND DOCUMENTATION
 
     You can also look for information at:
 
-        Search CPAN
-            http://search.cpan.org/dist/Sys-Syslog/
-
         MetaCPAN
             https://metacpan.org/module/Sys::Syslog
 

--- a/README
+++ b/README
@@ -44,9 +44,6 @@ SUPPORT AND DOCUMENTATION
         CPAN Request Tracker:
             http://rt.cpan.org/NoAuth/Bugs.html?Dist=Sys-Syslog
 
-        AnnoCPAN, annotated CPAN documentation:
-            http://annocpan.org/dist/Sys-Syslog
-
         CPAN Ratings:
             http://cpanratings.perl.org/d/Sys-Syslog
 

--- a/README.pod
+++ b/README.pod
@@ -40,10 +40,6 @@ You can also look for information at:
 
 =over
 
-=item * Search CPAN
-
-L<http://search.cpan.org/dist/Sys-Syslog/>
-
 =item * MetaCPAN
 
 L<https://metacpan.org/module/Sys::Syslog>

--- a/README.pod
+++ b/README.pod
@@ -48,10 +48,6 @@ L<https://metacpan.org/module/Sys::Syslog>
 
 L<http://perldoc.perl.org/Sys/Syslog.html>
 
-=item * AnnoCPAN: Annotated CPAN documentation
-
-L<http://annocpan.org/dist/Sys-Syslog>
-
 =item * CPAN Ratings
 
 L<http://cpanratings.perl.org/d/Sys-Syslog>

--- a/Syslog.pm
+++ b/Syslog.pm
@@ -1714,10 +1714,6 @@ L<http://perldoc.perl.org/Sys/Syslog.html>
 
 L<https://metacpan.org/module/Sys::Syslog>
 
-=item * Search CPAN
-
-L<http://search.cpan.org/dist/Sys-Syslog/>
-
 =item * AnnoCPAN: Annotated CPAN documentation
 
 L<http://annocpan.org/dist/Sys-Syslog>

--- a/Syslog.pm
+++ b/Syslog.pm
@@ -1714,10 +1714,6 @@ L<http://perldoc.perl.org/Sys/Syslog.html>
 
 L<https://metacpan.org/module/Sys::Syslog>
 
-=item * AnnoCPAN: Annotated CPAN documentation
-
-L<http://annocpan.org/dist/Sys-Syslog>
-
 =item * CPAN Ratings
 
 L<http://cpanratings.perl.org/d/Sys-Syslog>


### PR DESCRIPTION
Search.cpan.org is no longer a thing, the links redirect to metacpan,
which links are already present in the documentation.

This commit removes these duplicated links.